### PR TITLE
fix: support parameter-less actions

### DIFF
--- a/blonk_bot/src/collections/handler.rs
+++ b/blonk_bot/src/collections/handler.rs
@@ -5,6 +5,7 @@ use teloxide::types::UserId;
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct InternalActionData {
     pub actions: Vec<Action>,
+    pub base_url: String,
     pub url: String,
     pub action_title: String,
     pub action_description: String,

--- a/blonk_bot/src/handlers/handle_blink_url.rs
+++ b/blonk_bot/src/handlers/handle_blink_url.rs
@@ -7,11 +7,14 @@ use teloxide::{
     prelude::*,
     types::{InlineKeyboardButton, InlineKeyboardMarkup, ParseMode},
 };
+use url::Url;
 
 pub async fn handle_blink_url(bot: Bot, dialogue: MyDialogue, msg: Message) -> HandlerResult {
     match msg.text() {
         Some(url) => {
             let response = get_blink_metadata(&url.to_string()).await;
+            let parsed_url = Url::parse(url)?;
+            let base_url = format!("{}://{}", parsed_url.scheme(), parsed_url.host().unwrap());
 
             match response {
                 Ok(res) => {
@@ -42,6 +45,7 @@ pub async fn handle_blink_url(bot: Bot, dialogue: MyDialogue, msg: Message) -> H
                                 action_title: res.title,
                                 action_description: res.description,
                                 user_id: msg.from.clone().unwrap().id,
+                                base_url,
                             };
 
                             dialogue

--- a/blonk_bot/src/handlers/handle_external_action.rs
+++ b/blonk_bot/src/handlers/handle_external_action.rs
@@ -13,6 +13,15 @@ pub async fn handle_external_action(
         _ => return Ok(()),
     };
 
+    if let Err(e) = bot
+        .answer_callback_query(&q.id)
+        .text("Processing request...")
+        .show_alert(false)
+        .await
+    {
+        eprintln!("Failed to answer callback query: {}", e);
+    }
+
     let transaction_entry = crate::requests::get_transaction(button_metadata.transaction_id).await;
     let multisig_pubkey = get_multisig_pubkey();
 

--- a/blonk_bot/src/handlers/handle_internal_action.rs
+++ b/blonk_bot/src/handlers/handle_internal_action.rs
@@ -1,5 +1,5 @@
 use crate::collections::{Handler, HandlerResult, InternalActionData, MyDialogue, ParametersData};
-use crate::requests::{get_blink_transaction, get_multisig_account, get_transaction_account};
+use crate::requests::{get_multisig_account, get_transaction_account};
 use crate::utils::{
     get_group_chat_id, get_multisig_pubkey, get_transaction_request_buttons,
     get_transaction_request_message, get_url_root,
@@ -25,16 +25,55 @@ pub async fn handle_internal_action(
                 match parameters {
                     Some(parameters_res) => {
                         if parameters_res.is_empty() {
-                            let multisig_pubkey = get_multisig_pubkey();
-                            let transaction_response =
-                                get_blink_transaction(multisig_pubkey, &data.url).await?;
+                            bot.send_message(dialogue.chat_id(), "Processing blink...".to_string())
+                                .await?;
 
-                            bot.send_message(
-                                dialogue.chat_id(),
-                                transaction_response.transaction.to_string(),
+                            let action_url = format!("{}{}", data.base_url, action.unwrap().href);
+                            let multisig_pubkey = get_multisig_pubkey();
+                            let transaction_entry = crate::actions::create_transaction(
+                                &action_url,
+                                multisig_pubkey,
+                                data.user_id,
                             )
-                            .parse_mode(ParseMode::Html)
-                            .await?;
+                            .await;
+                            let multisig_account = get_multisig_account(multisig_pubkey).await;
+                            let threshold = multisig_account.threshold;
+                            let transaction_account = get_transaction_account(
+                                multisig_pubkey,
+                                transaction_entry.transaction_index,
+                            )
+                            .await;
+
+                            let template = get_transaction_request_message(
+                                data.action_title,
+                                data.action_description,
+                                None,
+                                transaction_entry.transaction_index,
+                            );
+
+                            let buttons = get_transaction_request_buttons(
+                                transaction_entry.id,
+                                threshold,
+                                1,
+                                0,
+                                &transaction_account.status,
+                            );
+
+                            let group_chat_id = get_group_chat_id();
+                            let group_message = bot
+                                .send_message(group_chat_id, template)
+                                .parse_mode(ParseMode::Html)
+                                .reply_markup(InlineKeyboardMarkup::new([buttons]))
+                                .await?;
+
+                            crate::requests::update_transaction(
+                                transaction_entry.id,
+                                group_message.id,
+                            )
+                            .await;
+
+                            bot.send_message(dialogue.chat_id(), "Transaction sent!".to_string())
+                                .await?;
 
                             dialogue.exit().await?;
                         } else {
@@ -97,6 +136,8 @@ pub async fn handle_internal_action(
                         }
                     }
                     None => {
+                        // TODO: Does it ever gets here?
+
                         let multisig_pubkey = get_multisig_pubkey();
                         let transaction_entry = crate::actions::create_transaction(
                             &data.url,

--- a/blonk_bot/src/handlers/handle_parameters.rs
+++ b/blonk_bot/src/handlers/handle_parameters.rs
@@ -70,6 +70,9 @@ pub async fn handle_parameters(
                     ));
                 }
 
+                bot.send_message(dialogue.chat_id(), "Processing blink...".to_string())
+                    .await?;
+
                 let multsig_pubkey = get_multisig_pubkey();
                 let transaction_entry =
                     crate::actions::create_transaction(&request_url, multsig_pubkey, data.user_id)


### PR DESCRIPTION
Actions without parameters don't have a template and lack the proper formatting, this PR fixes it by extracting the base_url from the blink's url itself. 

Note: This also sends an additional message "Processing blink..." to give users a bit more awareness.